### PR TITLE
Use before_action instead of before_filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ If you want to maintain this project, contact me (batdevis[at]gmail.com) and I w
 
 Include [swagger-ui](https://github.com/swagger-api/swagger-ui) as rails engine.
 
+Current master works with Rails 4.0+. If you're looking for Rails 3.0 support,
+try version 0.0.3.
+
 ## Swagger specifications
 
 https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md

--- a/app/controllers/swagger_engine/application_controller.rb
+++ b/app/controllers/swagger_engine/application_controller.rb
@@ -1,7 +1,7 @@
 module SwaggerEngine
   class ApplicationController < ActionController::Base
 
-    before_filter :authenticate
+    before_action :authenticate
 
     protected
     def authenticate

--- a/app/controllers/swagger_engine/swaggers_controller.rb
+++ b/app/controllers/swagger_engine/swaggers_controller.rb
@@ -4,7 +4,7 @@ module SwaggerEngine
   class SwaggersController < ApplicationController
     layout false
 
-    before_filter :load_json_files
+    before_action :load_json_files
 
     def index
       redirect_to swagger_path(@json_files.first[0]) if ( @json_files.size == 1 )

--- a/lib/swagger_engine/version.rb
+++ b/lib/swagger_engine/version.rb
@@ -1,3 +1,3 @@
 module SwaggerEngine
-  VERSION = "0.0.3"
+  VERSION = "0.1.0"
 end

--- a/swagger_engine.gemspec
+++ b/swagger_engine.gemspec
@@ -16,4 +16,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
+
+  s.add_runtime_dependency "railties", ">= 4.0", "< 6.0"
 end


### PR DESCRIPTION
Rails 5.1 removes support for legacy `before_filter`, therefore engine's code needs to be updated. This change breaks compatibility with Rails 3.x but fixes it with Rails 5.1.